### PR TITLE
add new stop-after-chapter property to dvdreadsrc

### DIFF
--- a/ext/dvdread/dvdreadsrc.h
+++ b/ext/dvdread/dvdreadsrc.h
@@ -56,10 +56,12 @@ struct _GstDvdReadSrc {
 
   gint             uri_title;     /* set via the URI handler or properties,  */
   gint             uri_chapter;   /* otherwise not touched; these values     */
+  gint             uri_stop_after_chapter;
   gint             uri_angle;     /* start from 1                            */
 
   gint             title;         /* current position while open, set to the */
   gint             chapter;       /* URI-set values in ::start(). these      */
+  gint             stop_after_chapter;
   gint             angle;         /* values start from 0                     */
 
   gint             start_cell, last_cell, cur_cell;


### PR DESCRIPTION
I wanted the ability to specify a range of chapters to the dvdreadsrc plugin.  Since it appeared to lack the properties and the logic necessary, I tried to code it myself.

It seems to work in my limited testing.

I would appreciate if this could be incorporated into the official source so I don't have to run a custom plugin for my applications.